### PR TITLE
`timetable-to-ical`: switch to `chrono` for timekeeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +484,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -1322,7 +1332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -1332,7 +1351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -1341,7 +1360,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -1352,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1363,6 +1382,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1781,7 +1809,7 @@ dependencies = [
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
@@ -1969,7 +1997,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -1981,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -2091,6 +2119,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "chrono-tz",
  "ics",
  "kreta-combine",
  "kreta-rs",
@@ -2492,7 +2521,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",

--- a/login_test/src/main.rs
+++ b/login_test/src/main.rs
@@ -62,7 +62,7 @@ async fn gen_timetable() -> anyhow::Result<()> {
 		..Default::default()
 	};
 
-	let timetable = client.timetable("2025-09-25", "2025-10-23").await?;
+	let timetable = client.timetable("2025-10-21", "2025-11-04").await?;
 	let calendar = timetable_to_ical::lessons_to_calendar_file(&timetable, &opts);
 
 	tokio::fs::write("./timetable.ical", &calendar).await?;

--- a/timetable-to-ical/Cargo.toml
+++ b/timetable-to-ical/Cargo.toml
@@ -14,3 +14,4 @@ kreta-rs = { workspace = true, default-features = false }
 kreta-combine = { workspace = true, optional = true }
 uuid = { version = "1.18.1", features = ["v4"] }
 anyhow = { workspace = true, optional = true }
+chrono-tz = "0.10.4"

--- a/timetable-to-ical/src/combine.rs
+++ b/timetable-to-ical/src/combine.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use ics::ICalendar;
 use kreta_rs::client::Client;
 
@@ -17,11 +18,18 @@ pub async fn combined_calendar_file(
 			homework: lesson.homework.as_ref(),
 			exam: lesson.exam.as_ref(),
 		};
-		crate::lesson_to_event_explicit(&lesson.lesson_raw, opts, extra_data)
+		(
+			lesson,
+			crate::lesson_to_event_explicit(&lesson.lesson_raw, opts, extra_data),
+		)
 	});
 	let calendar = {
 		let mut calendar = ICalendar::new("2.0", "timetable-to-ical");
-		for event in events {
+		for (lesson, event) in events {
+			let event = event.with_context(|| {
+				format!("calling lesson_to_event_explicit returned an error\nlesson:\n{lesson:#?}")
+			})?;
+
 			calendar.add_event(event);
 		}
 


### PR DESCRIPTION
(even across timezones)
also fixed all-day events showing up on the previous day